### PR TITLE
Add keymap for moving line

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,13 @@ You need to install it beforehand.
 Use `M-x point-history-show` and you can open `point-history-show-buffer` with history.  
 Then you can select the point in history and press `Enter` to jump to its position.
 
+When you want to change the keymap in `point-history-show-buffer`, edit init.el as below.
+
+```elisp
+(define-key point-history-show-mode-map (kbd "n") 'point-history-next-line)
+(define-key point-history-show-mode-map (kbd "p") 'point-history-prev-line)
+```
+
 ## Customizable variables
 
 |variable|usage|default value|

--- a/point-history.el
+++ b/point-history.el
@@ -84,9 +84,9 @@
 
 (defun point-history-next-line ()
   "Go to next line in `point-history-show-mode'.
-If current-line is end of the buffer, go to the first line."
+If the current line number is end of the buffer, go to the first line."
   (interactive)
-  (let* ((current-line-num (+ 1 (current-line)))
+  (let* ((current-line-num (line-number-at-pos))
          (begining-line-num 1)
          (total-line-num (count-lines (point-min) (point-max))))
     (if (>= current-line-num total-line-num)
@@ -95,9 +95,9 @@ If current-line is end of the buffer, go to the first line."
 
 (defun point-history-prev-line ()
   "Go to previous line in `point-history-show-mode'.
-If current-line is begining of the buffer, go to the last line."
+If the current line number is begining of the buffer, go to the last line."
   (interactive)
-  (let* ((current-line-num (+ 1 (current-line)))
+  (let* ((current-line-num (line-number-at-pos))
          (begining-line-num 1)
          (total-line-num (count-lines (point-min) (point-max))))
     (if (<= current-line-num begining-line-num)

--- a/point-history.el
+++ b/point-history.el
@@ -57,6 +57,10 @@
 (defvar point-history-show-mode-map
   (let ((kmap (make-sparse-keymap)))
     (define-key kmap (kbd "RET") 'point-history-goto)
+    (define-key kmap (kbd "n") 'point-history-next-line)
+    (define-key kmap (kbd "TAB") 'point-history-next-line)
+    (define-key kmap (kbd "p") 'point-history-prev-line)
+    (define-key kmap (kbd "<C-tab>") 'point-history-prev-line)
     kmap))
 
 (defun point-history-show-mode nil
@@ -77,6 +81,28 @@
 	(message "No point at this line.")
       (pop-to-buffer (get-buffer buffer-str))
       (goto-char pos))))
+
+(defun point-history-next-line ()
+  "Go to next line in `point-history-show-mode'.
+If current-line is end of the buffer, go to the first line."
+  (interactive)
+  (let* ((current-line-num (+ 1 (current-line)))
+         (begining-line-num 1)
+         (total-line-num (count-lines (point-min) (point-max))))
+    (if (>= current-line-num total-line-num)
+        (goto-line begining-line-num)
+      (goto-line (+ 1 current-line-num)))))
+
+(defun point-history-prev-line ()
+  "Go to previous line in `point-history-show-mode'.
+If current-line is begining of the buffer, go to the last line."
+  (interactive)
+  (let* ((current-line-num (+ 1 (current-line)))
+         (begining-line-num 1)
+         (total-line-num (count-lines (point-min) (point-max))))
+    (if (<= current-line-num begining-line-num)
+        (goto-line total-line-num)
+      (goto-line (- current-line-num 1)))))
 
 (defun point-history--build-unique-list! ()
   "Delete duplicated element in point-history-list."


### PR DESCRIPTION
Related issue: https://github.com/blue0513/point-history/issues/1

+ Add default keymap for moving line in `point-history-show-buffer`
~+ Enable `hl-mode` in `point-history-show-buffer`~
