### PR TITLE
Update file header in include file extension

### DIFF
--- a/point-history.el
+++ b/point-history.el
@@ -1,4 +1,4 @@
-;;; point-history --- Show the history of points you visited before
+;;; point-history.el --- Show the history of points you visited before
 
 ;; Copyright (C) 2019- blue0513
 


### PR DESCRIPTION
This change allows point-history to be installed via Quelpa, which requires a header2.el conformant file header section.  Either a mode declaration or file ext is required.

Reference: https://www.emacswiki.org/emacs/AutomaticFileHeaders

> Why should I place -*- Mode: Emacs-Lisp -*- at the top? header2.el works for any time of file, not just EmacsLisp files. And for Emacs-Lisp files that have file extension el or elc there is no need for a mode declaration in the header.

By adding the file ext, the file header path is recognized by package building tools.

Example: The following will only work when the header file name is specified.

```elisp
(package-install 'quelpa-use-package)
(require 'quelpa-use-package)

(use-package popwin :defer t)

;; working - with file ext
(use-package point-history
  :defer t
  :after (popwin)
  :quelpa (point-history :fetcher github :repo "jclosure/point-history"))

;; not working - no file ext
(use-package point-history
   :defer t
   :after (popwin)
   :quelpa (point-history :fetcher github :repo "blue0513/point-history"))
```

Issue:
```
Debugger entered--Lisp error: (error "Package lacks a file header")
  signal(error ("Package lacks a file header"))
  error("Package lacks a file header")
  package-buffer-info()
  quelpa-get-package-desc("/Users/jholder/.emacs.d/quelpa/packages/point-history-20190507.2154.el")
  quelpa-package-install((point-history :fetcher github :repo "blue0513/point-history"))
  apply(quelpa-package-install (point-history :fetcher github :repo "blue0513/point-history") nil)
  quelpa((point-history :fetcher github :repo "blue0513/point-history"))
  eval((quelpa '(point-history :fetcher github :repo "blue0513/point-history")) nil)
  elisp--eval-last-sexp(nil)
  eval-last-sexp(nil)
  funcall-interactively(eval-last-sexp nil)
  call-interactively(eval-last-sexp nil nil)
  command-execute(eval-last-sexp)
```